### PR TITLE
Fix action output definitions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: "A list of service names to ignore when redeploying the PR environment. This is useful for services that don't need to be redeployed on every PR deployment."
     required: false
 outputs:
-  domain:
+  service_domain:
     description: "The domain of the deployed PR environment"
 runs:
   using: "node16"


### PR DESCRIPTION
Hey @Faolain,

It seems like the action output definition is wrong which causes linter warnings. I think this PR should fix it.

Thank you for your consideration.